### PR TITLE
Add vector compression for PVector nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ PROGRAM                = libpbvt.so
 EXTRA_CFLAGS           = -ggdb3 -fPIC -fdata-sections -ffunction-sections -fvisibility=hidden -nostdlib #-fsanitize=address
 
 # The extra linker options, e.g. "-lmysqlclient -lz"
-EXTRA_LDFLAGS          = 
+EXTRA_LDFLAGS          = -lunwind -lunwind-x86_64
 
 # Specify the include dirs, e.g. "-I/usr/include/mysql -I./include -I/usr/include -I/usr/local/include".
 INCLUDE                = -Iinclude
@@ -90,8 +90,8 @@ HDREXTS = .h .H .hh .hpp .HPP .h++ .hxx .hp
 
 # The pre-processor and compiler options.
 # Users can override those variables from the command line.
-CFLAGS  = -O1 # -DNDEBUG -DMDEBUG
-CXXFLAGS= -O1 # -DNDEBUG -DMDEBUG
+CFLAGS  = -O2 -DNDEBUG # -DMDEBUG
+CXXFLAGS= -O2 -DNDEBUG # -DMDEBUG
 
 # The command used to delete file.
 RM     = rm -f

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ HDREXTS = .h .H .hh .hpp .HPP .h++ .hxx .hp
 
 # The pre-processor and compiler options.
 # Users can override those variables from the command line.
-CFLAGS  = -O3 -DNDEBUG # -DMDEBUG
-CXXFLAGS= -O3 -DNDEBUG # -DMDEBUG
+CFLAGS  = -O1 # -DNDEBUG -DMDEBUG
+CXXFLAGS= -O1 # -DNDEBUG -DMDEBUG
 
 # The command used to delete file.
 RM     = rm -f

--- a/driver.c
+++ b/driver.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <coz.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -6,6 +5,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include "cassert.h"
 #include "pbvt.h"
 
 #define MIN(a, b) ((a) > (b) ? (b) : (a))

--- a/examples/bench.c
+++ b/examples/bench.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "pbvt.h"
+
+#define ARRAY_SIZE 10
+#define KEY 0xAA
+
+void encrypt(uint8_t *data, uint8_t key, size_t size) {
+  for (size_t i = 0; i < size; ++i) {
+    data[i] ^= key;
+  }
+}
+
+int main(int argc, char **argv) {
+  pbvt_init();
+
+  size_t data_sz = 0x20;
+  uint8_t *data = pbvt_calloc(data_sz, sizeof(uint8_t));
+  for (int i = 0; i < data_sz; ++i)
+    data[i] = i;
+
+  for (int i = 0; i < 0x10000; ++i) {
+    encrypt(data, i, data_sz);
+    pbvt_commit();
+  }
+  pbvt_stats();
+
+  return 0;
+}

--- a/examples/bench.c
+++ b/examples/bench.c
@@ -15,16 +15,18 @@ void encrypt(uint8_t *data, uint8_t key, size_t size) {
 int main(int argc, char **argv) {
   pbvt_init();
 
-  size_t data_sz = 0x20;
-  uint8_t *data = pbvt_calloc(data_sz, sizeof(uint8_t));
-  for (int i = 0; i < data_sz; ++i)
-    data[i] = i;
+  srand(0);
 
-  for (int i = 0; i < 0x10000; ++i) {
-    encrypt(data, i, data_sz);
+  size_t data_sz = 0x1000;
+  uint8_t *data = pbvt_calloc(data_sz, sizeof(uint8_t));
+  for (int i = 0; i < 0x80000; ++i) {
+    for (int j = 0; j < data_sz; ++j)
+      data[j] = rand();
+
     pbvt_commit();
+    if (i % 0x1000 == 0)
+      pbvt_stats();
   }
-  pbvt_stats();
 
   return 0;
 }

--- a/examples/test-update-n.c
+++ b/examples/test-update-n.c
@@ -1,0 +1,33 @@
+#include "hashtable.h"
+#include "memory.h"
+#include "pvector.h"
+
+#define BASE_ADDR (0x1000)
+
+int main(int argc, char **argv) {
+  char buf[0x1000];
+  for (int i = 0; i < sizeof(buf) / sizeof(char); ++i)
+    buf[i] = i % 0x40;
+
+  PVector *v = memory_calloc(NULL, 1, sizeof(PVector));
+  v->hash = 0UL;
+  v->refcount = 1;
+
+  ht = ht_create();
+  ht_insert(ht, 0UL, v);
+
+  for (int i = 0; i < 0x100; ++i) {
+    PVector *t = pvector_update_n(v, BASE_ADDR, buf, sizeof(buf));
+    pvector_gc(v, MAX_DEPTH - 1);
+    v = t;
+  }
+
+  for (int i = 0; i < sizeof(buf); ++i) {
+    if (buf[i] != pvector_get(v, BASE_ADDR + i)) {
+      printf("mismatch at %d: buf[%d]==%d, v[%d]==%d", i, i, buf[i], i,
+             pvector_get(v, BASE_ADDR + i));
+    }
+  }
+  printf("All matched! %d\n", sizeof(buf));
+  return 0;
+}

--- a/examples/track-clone.c
+++ b/examples/track-clone.c
@@ -13,7 +13,7 @@
 int child(void *arg) {
   uint64_t *counter = arg;
   *counter = 0;
-  for (uint64_t i = 0; i < 0x100000000; ++i)
+  for (uint64_t i = 0; i < 0x1000000000; ++i)
     *counter = i;
   write(1, "Goodbye!\n", 9);
 }

--- a/examples/watchpoints.c
+++ b/examples/watchpoints.c
@@ -1,6 +1,5 @@
 // cc examples/watchpoints.c -O2 -Iinclude -lpbvt -o watchpoints
 
-#include <assert.h>
 #include <sys/mman.h>
 
 #include "pbvt.h"

--- a/include/cassert.h
+++ b/include/cassert.h
@@ -1,0 +1,13 @@
+#pragma once
+
+void custom_assert(char *file, char *function, int line, char *str,
+                   int condition);
+
+#ifndef NDEBUG
+#define assert(x)                                                              \
+  do {                                                                         \
+    custom_assert(__FILE__, __FUNCTION__, __LINE__, #x, x)\                        \
+  } while (0);
+#else
+#define assert(x)
+#endif

--- a/include/fasthash.h
+++ b/include/fasthash.h
@@ -39,7 +39,7 @@ extern "C" {
  * @len:  data size
  * @seed: the seed
  */
-	uint32_t fasthash32(const void *buf, size_t len, uint32_t seed);
+uint32_t fasthash32(const void *buf, size_t len, uint32_t seed);
 
 /**
  * fasthash64 - 64-bit implementation of fasthash
@@ -47,7 +47,7 @@ extern "C" {
  * @len:  data size
  * @seed: the seed
  */
-	uint64_t fasthash64(const void *buf, size_t len, uint64_t seed);
+uint64_t fasthash64(const void *buf, size_t len, uint64_t seed);
 
 #ifdef __cplusplus
 }

--- a/include/memory.h
+++ b/include/memory.h
@@ -44,7 +44,7 @@ mucking around with any internal state in malloc.
 */
 
 // Make sure this matches sizeof(BIN_SIZES)/sizeof(BIN_SIZES[0]) in memory.c
-#define NUM_BINS (6)
+#define NUM_BINS (7)
 // This can be tuned, must be power of 2 greater than pagesize
 #define BIN_SIZE (1 << 14)
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#include <pthread.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -43,8 +46,8 @@ mucking around with any internal state in malloc.
 
 */
 
-// Make sure this matches sizeof(BIN_SIZES)/sizeof(BIN_SIZES[0]) in memory.c
 #define NUM_BINS (7)
+
 // This can be tuned, must be power of 2 greater than pagesize
 #define BIN_SIZE (1 << 14)
 

--- a/include/pvector.h
+++ b/include/pvector.h
@@ -2,13 +2,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// For 4-level paging (see "Paging" in Volume 3 of the Intel 64 and IA-32
-// Architectures Software Developer's manual)
-#define NUM_BITS (45+5)
-// #define BITS_PER_LEVEL (9)
-// #define BOTTOM_BITS (12)
-#define BITS_PER_LEVEL (5)
-#define BOTTOM_BITS (5)
+// For 4-level paging we need at least 48 bits of key (see "Paging" in Volume 3
+// of the Intel 64 and IA-32 Architectures Software Developer's manual)
+#define NUM_BITS (42+7)
+#define BITS_PER_LEVEL (3)
+#define BOTTOM_BITS (7)
 
 // Calculated defines, make sure (NUM_BITS - BOTTOM_BITS) % BITS_PER_LEVEL == 0
 #if (NUM_BITS - BOTTOM_BITS) % BITS_PER_LEVEL != 0
@@ -32,8 +30,8 @@ typedef struct PVector PVector;
 typedef struct PVector {
   uint64_t hash;
   uint64_t refcount;
-  uint64_t bitmap[(NUM_CHILDREN + (8 * sizeof(uint64_t)) - 1) /
-                  (8 * sizeof(uint64_t))];
+  uint16_t bitmap[(NUM_CHILDREN + (8 * sizeof(uint16_t)) - 1) /
+                  (8 * sizeof(uint16_t))];
   uint64_t *children;
 } PVector;
 

--- a/include/pvector.h
+++ b/include/pvector.h
@@ -4,11 +4,11 @@
 
 // For 4-level paging (see "Paging" in Volume 3 of the Intel 64 and IA-32
 // Architectures Software Developer's manual)
-#define NUM_BITS (48+3)
-// #define BITS_PER_LEVEL (3)
-// #define BOTTOM_BITS (3)
-#define BITS_PER_LEVEL (6)
-#define BOTTOM_BITS (3)
+#define NUM_BITS (45+5)
+// #define BITS_PER_LEVEL (9)
+// #define BOTTOM_BITS (12)
+#define BITS_PER_LEVEL (5)
+#define BOTTOM_BITS (5)
 
 // Calculated defines, make sure (NUM_BITS - BOTTOM_BITS) % BITS_PER_LEVEL == 0
 #if (NUM_BITS - BOTTOM_BITS) % BITS_PER_LEVEL != 0

--- a/include/pvector.h
+++ b/include/pvector.h
@@ -4,11 +4,11 @@
 
 // For 4-level paging (see "Paging" in Volume 3 of the Intel 64 and IA-32
 // Architectures Software Developer's manual)
-#define NUM_BITS (48)
-#define BITS_PER_LEVEL (3)
+#define NUM_BITS (48+3)
+// #define BITS_PER_LEVEL (3)
+// #define BOTTOM_BITS (3)
+#define BITS_PER_LEVEL (6)
 #define BOTTOM_BITS (3)
-//#define BITS_PER_LEVEL (9)
-//#define BOTTOM_BITS (12)
 
 // Calculated defines, make sure (NUM_BITS - BOTTOM_BITS) % BITS_PER_LEVEL == 0
 #if (NUM_BITS - BOTTOM_BITS) % BITS_PER_LEVEL != 0
@@ -32,7 +32,9 @@ typedef struct PVector PVector;
 typedef struct PVector {
   uint64_t hash;
   uint64_t refcount;
-  uint64_t children[NUM_CHILDREN];
+  uint64_t bitmap[(NUM_CHILDREN + (8 * sizeof(uint64_t)) - 1) /
+                  (8 * sizeof(uint64_t))];
+  uint64_t *children;
 } PVector;
 
 typedef struct PVectorLeaf {

--- a/src/cassert.c
+++ b/src/cassert.c
@@ -1,0 +1,31 @@
+
+#include <libunwind.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void custom_assert(char *file, char *function, int line, char *str,
+                   int condition) {
+  if (!condition) {
+    unw_cursor_t cursor;
+    unw_context_t context;
+
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
+
+    fprintf(stderr, "%s:%d: %s '%s' failed! Stack trace:\n", file, line,
+            function, str);
+
+    while (unw_step(&cursor) > 0) {
+      unw_word_t offset, pc;
+      char fname[64];
+
+      unw_get_reg(&cursor, UNW_REG_IP, &pc);
+      fname[0] = '\0';
+      unw_get_proc_name(&cursor, fname, sizeof(fname), &offset);
+
+      fprintf(stderr, "%p : (%s+0x%lx)\n", (void *)pc, fname, (long)offset);
+    }
+
+    exit(EXIT_FAILURE);
+  }
+}

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -19,25 +19,8 @@ HashTable *ht_create(void) {
 void *ht_get(HashTable *ht, uint64_t key) {
   HashBucket *bucket = &ht->buckets[key & (ht->cap - 1)];
   for (size_t i = 0; i < bucket->size; ++i)
-    if (bucket->keys[i] == key) {
-#if 0
-      if (i > 0) {
-        uint64_t temp_key;
-        void *temp_value;
-        memcpy(&temp_key, &bucket->keys[i], sizeof(temp_key));
-        memcpy(&temp_value, &bucket->values[i], sizeof(temp_value));
-
-        memcpy(&bucket->keys[i], &bucket->keys[0], sizeof(temp_key));
-        memcpy(&bucket->values[i], &bucket->values[0], sizeof(temp_value));
-
-        memcpy(&bucket->keys[0], &temp_key, sizeof(temp_key));
-        memcpy(&bucket->values[0], &temp_value, sizeof(temp_value));
-      }
-      return bucket->values[0];
-#else
+    if (bucket->keys[i] == key)
       return bucket->values[i];
-#endif
-    }
   return NULL;
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1,6 +1,6 @@
-#include <assert.h>
 #include <string.h>
 
+#include "cassert.h"
 #include "hashtable.h"
 #include "mmap_malloc.h"
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -9,8 +9,8 @@
 
 // Make sure this matches NUM_BINS in memory.h
 // TODO: Add sizeof(PVector), sizeof(PVectorLeaf) as dedicated bin sizes
-const size_t BIN_BITS[] = {2, 3, 4, 5, 6, 7};
-const size_t BIN_SIZES[] = {4, 8, 16, 32, 64, 128};
+const size_t BIN_BITS[] = { 3, 4, 5, 6, 7, 8, 9};
+const size_t BIN_SIZES[] = { 8, 16, 32, 64, 128, 256, 512};
 
 MallocState global_heap;
 // Allocate new bin for holding allocations of `size`
@@ -150,7 +150,7 @@ found_size:
   }
 
   // Ensure sure the first bin always has enough room for more allocations
-  if (bin->sz + 2 >= bin->cap) {
+  if (bin->sz + 1 == bin->cap) {
     BinHdr *nbin = allocate_bin(ms, BIN_SIZES[idx]);
     nbin->idx = idx;
     if (ms->bins[idx]) {
@@ -159,9 +159,10 @@ found_size:
       ms->bins[idx]->prev = nbin;
     }
     ms->bins[idx] = nbin;
+    bin = nbin;
   }
 
-  assert(bin->sz + 1 <= bin->cap);
+  assert(bin->sz + 1 < bin->cap);
 
   size_t i = bv_find_first_zero(bin->bitmap, bin->cap);
   bv_set(bin->bitmap, i);

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,4 +1,6 @@
-#include <assert.h>
+// #include <assert.h>
+#include <libunwind.h>
+#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -7,10 +9,38 @@
 #include "fasthash.h"
 #include "memory.h"
 
+void my_assert(char *file, char *function, int line, char *str, int condition) {
+  if (!condition) {
+    unw_cursor_t cursor;
+    unw_context_t context;
+
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
+
+    fprintf(stderr, "%s:%ld: %s '%s' failed! Stack trace:\n", file, line,
+            function, str);
+
+    while (unw_step(&cursor) > 0) {
+      unw_word_t offset, pc;
+      char fname[64];
+
+      unw_get_reg(&cursor, UNW_REG_IP, &pc);
+      fname[0] = '\0';
+      unw_get_proc_name(&cursor, fname, sizeof(fname), &offset);
+
+      fprintf(stderr, "%p : (%s+0x%lx)\n", (void *)pc, fname, (long)offset);
+    }
+
+    exit(EXIT_FAILURE);
+  }
+}
+
+#define assert(x) my_assert(__FILE__, __FUNCTION__, __LINE__, #x, x)
+
 // Make sure this matches NUM_BINS in memory.h
 // TODO: Add sizeof(PVector), sizeof(PVectorLeaf) as dedicated bin sizes
-const size_t BIN_BITS[] = { 3, 4, 5, 6, 7, 8, 9};
-const size_t BIN_SIZES[] = { 8, 16, 32, 64, 128, 256, 512};
+const size_t BIN_BITS[] = {3, 4, 5, 7, 8, 9};
+const size_t BIN_SIZES[] = {8, 16, 32, 128, 256, 512};
 
 MallocState global_heap;
 // Allocate new bin for holding allocations of `size`
@@ -93,6 +123,8 @@ void *memory_realloc(MallocState *ms, void *ptr, size_t size) {
   BinHdr *bin = ht_get(ms->bt, fasthash64(&key, sizeof(key), 0));
   size_t idx = bin->idx;
 
+  assert(ptr < (void *)bin + bin->memsz);
+
   if (bin == NULL)
     assert(0 && "No bin found!");
 
@@ -103,8 +135,10 @@ void *memory_realloc(MallocState *ms, void *ptr, size_t size) {
     memcpy(dstptr, ptr, (void *)bin + bin->memsz - bin->contents);
   memory_free(ms, ptr);
 #ifdef MDEBUG
-  printf("realloc(%p, %ld); // bin: %p, %p\n", ptr, size, bin, dstptr);
+  printf("realloc(%.16lx, %ld); // bin: %.16lx, %.16lx\n", ptr, size, bin,
+         dstptr);
 #endif
+
   return dstptr;
 }
 
@@ -129,7 +163,8 @@ void *memory_malloc(MallocState *ms, size_t size) {
   ms->bins[idx] = bin;
   bin->sz += 1;
 #ifdef MDEBUG
-  printf("malloc(0x%lx); // oversize: %p\n", size, bin->contents);
+  printf("malloc(0x%lx); // oversize: %.16lx bin: %.16lx\n", size,
+         bin->contents, bin);
 #endif
   ms->current_bytes += bin->memsz;
   ms->current_allocations += 1;
@@ -172,7 +207,7 @@ found_size:
   ms->current_allocations += 1;
   ms->total_allocations += 1;
 #ifdef MDEBUG
-  printf("malloc(0x%lx); // %p\n", size, ptr);
+  printf("malloc(0x%lx); // %.16lx\n", size, ptr);
 #endif
   return ptr;
 }
@@ -180,9 +215,12 @@ found_size:
 void memory_free(MallocState *ms, void *ptr) {
   if (!ms)
     ms = &global_heap;
-
   if (ptr == NULL)
     return;
+
+#ifdef MDEBUG
+  printf("free(%.16lx);\n", ptr);
+#endif
 
   if (ms->bt == NULL)
     ms->bt = ht_create();
@@ -192,15 +230,22 @@ void memory_free(MallocState *ms, void *ptr) {
 
   uint64_t key = ((uintptr_t)ptr) & ~0xfff;
   bin = ht_get(ms->bt, fasthash64(&key, sizeof(key), 0));
+  assert(bin && "WARNING: No bin found!");
   idx = bin->idx;
 
-  assert(bin && "WARNING: No bin found!");
-
+  // Is this an allocation in the wilderness?
   if (idx < NUM_BINS) {
+    assert(bin <= ptr);
+    assert(ptr < (void *)bin + bin->memsz);
     size_t i = (ptr - bin->contents) >> BIN_BITS[idx];
+    if (!bv_is_set(bin->bitmap, i)) {
+      printf("Bin: %.16lx idx: %.16lx ptr: %.16lx BIN_BITS: %.16lx i: %.16lx "
+             "memsz: %.16lx\n",
+             bin, idx, ptr, BIN_BITS[idx], ptr - bin->contents, bin->memsz);
+    }
     assert(bv_is_set(bin->bitmap, i));
     bv_unset(bin->bitmap, i);
-    memset(ptr, 0x55, BIN_SIZES[idx]);
+    memset(ptr, 0x54, BIN_SIZES[idx]);
   }
 
   ms->current_allocations -= 1;
@@ -232,9 +277,6 @@ void memory_free(MallocState *ms, void *ptr) {
       assert(0 && "munmap failed!");
   }
 
-#ifdef MDEBUG
-  printf("free(%p);\n", ptr);
-#endif
   return;
 }
 

--- a/src/pbvt.c
+++ b/src/pbvt.c
@@ -22,7 +22,7 @@
 #include "pbvt.h"
 
 uint64_t get_child(PVector *n, int index);
-void set_bit(uint64_t *bitmap, int index);
+void set_bit(uint16_t *bitmap, int index);
 
 #define MIN(x, y) ((x) > (y) ? (y) : (x))
 #define MAX(x, y) ((x) > (y) ? (x) : (y))

--- a/src/pbvt.c
+++ b/src/pbvt.c
@@ -1,6 +1,5 @@
 #define _GNU_SOURCE
 
-#include <assert.h>
 #include <fcntl.h>
 #include <linux/userfaultfd.h>
 #include <malloc.h>
@@ -17,6 +16,7 @@
 #include <threads.h>
 #include <unistd.h>
 
+#include "cassert.h"
 #include "fasthash.h"
 #include "memory.h"
 #include "pbvt.h"
@@ -195,6 +195,7 @@ void pbvt_relocate_away_internal(Range *r) {
 void uffd_segv(int signo) {
   UNUSED(signo);
   printf("WARNING: got segfault in uffd_montior\n");
+  abort();
 }
 
 int uffd_monitor(void *args) {

--- a/src/pvector.c
+++ b/src/pvector.c
@@ -93,7 +93,7 @@ PVector *pvector_clone(PVector *v) {
   u->children = memory_calloc(NULL, 1, sizeof(uint64_t));
   for (size_t i = 0; i < NUM_CHILDREN; ++i)
     set_child(u, i, get_child(v, i));
-  printf("Set bits: %.16lx\n", count_set_bits(u->bitmap, NUM_CHILDREN-1));
+  // printf("Set bits: %.16lx\n", count_set_bits(u->bitmap, NUM_CHILDREN-1));
   return u;
 }
 

--- a/src/pvector.c
+++ b/src/pvector.c
@@ -1,6 +1,6 @@
-#include <assert.h>
 #include <string.h>
 
+#include "cassert.h"
 #include "fasthash.h"
 #include "hashtable.h"
 #include "memory.h"
@@ -61,16 +61,18 @@ void set_child(PVector *v, int index, uint64_t value) {
                 sizeof(uint64_t));
     v->children[compact_index] = value;
     set_bit(v->bitmap, index);
-  // } else if (is_bit_set(v->bitmap, index) && value == 0) {
-  //   // A child is being removed, resize the children array and update the bitmap
-  //   int compact_index = count_set_bits(v->bitmap, index) - 1;
-  //   memmove(&v->children[compact_index], &v->children[compact_index + 1],
-  //           (count_set_bits(v->bitmap, NUM_CHILDREN - 1) - compact_index - 1) *
-  //               sizeof(uint64_t));
-  //   v->children = memory_realloc(
-  //       NULL, v->children,
-  //       (count_set_bits(v->bitmap, NUM_CHILDREN - 1) - 1) * sizeof(uint64_t));
-  //   clear_bit(v->bitmap, index);
+    // } else if (is_bit_set(v->bitmap, index) && value == 0) {
+    //   // A child is being removed, resize the children array and update the
+    //   bitmap int compact_index = count_set_bits(v->bitmap, index) - 1;
+    //   memmove(&v->children[compact_index], &v->children[compact_index + 1],
+    //           (count_set_bits(v->bitmap, NUM_CHILDREN - 1) - compact_index -
+    //           1) *
+    //               sizeof(uint64_t));
+    //   v->children = memory_realloc(
+    //       NULL, v->children,
+    //       (count_set_bits(v->bitmap, NUM_CHILDREN - 1) - 1) *
+    //       sizeof(uint64_t));
+    //   clear_bit(v->bitmap, index);
   } else if (is_bit_set(v->bitmap, index)) {
     // Update the existing child
     int compact_index = count_set_bits(v->bitmap, index) - 1;

--- a/src/pvector.c
+++ b/src/pvector.c
@@ -10,11 +10,90 @@
 
 HashTable *ht;
 
+int is_bit_set(uint64_t *bitmap, int index) {
+  int array_index = index / 64;
+  int bit_index = index % 64;
+  return (bitmap[array_index] & (1ULL << bit_index)) != 0;
+}
+
+void set_bit(uint64_t *bitmap, int index) {
+  int array_index = index / 64;
+  int bit_index = index % 64;
+  bitmap[array_index] |= (1ULL << bit_index);
+}
+
+void clear_bit(uint64_t *bitmap, int index) {
+  int array_index = index / 64;
+  int bit_index = index % 64;
+  bitmap[array_index] &= ~(1ULL << bit_index);
+}
+
+size_t count_set_bits(uint64_t *bitmap, size_t index) {
+  size_t count = 0;
+  for (size_t i = 0; i <= index; i++)
+    if (is_bit_set(bitmap, i))
+      count++;
+  return count;
+}
+
+// Access a child using the sparse index
+uint64_t get_child(PVector *v, int index) {
+  // assert(v);
+  // return v->children[index];
+
+  if (!is_bit_set(v->bitmap, index))
+    return 0UL;
+  int compact_index = count_set_bits(v->bitmap, index) - 1;
+  return v->children[compact_index];
+}
+
+// Set a child using the sparse index
+void set_child(PVector *v, int index, uint64_t value) {
+  if (!is_bit_set(v->bitmap, index) && value != 0) {
+    // A new child is being added, resize the children array and update the
+    // bitmap
+    int compact_index = count_set_bits(v->bitmap, index);
+    v->children = memory_realloc(
+        NULL, v->children,
+        (count_set_bits(v->bitmap, NUM_CHILDREN - 1) + 1) * sizeof(uint64_t));
+    memmove(&v->children[compact_index + 1], &v->children[compact_index],
+            (count_set_bits(v->bitmap, NUM_CHILDREN - 1) - compact_index) *
+                sizeof(uint64_t));
+    v->children[compact_index] = value;
+    set_bit(v->bitmap, index);
+  // } else if (is_bit_set(v->bitmap, index) && value == 0) {
+  //   // A child is being removed, resize the children array and update the bitmap
+  //   int compact_index = count_set_bits(v->bitmap, index) - 1;
+  //   memmove(&v->children[compact_index], &v->children[compact_index + 1],
+  //           (count_set_bits(v->bitmap, NUM_CHILDREN - 1) - compact_index - 1) *
+  //               sizeof(uint64_t));
+  //   v->children = memory_realloc(
+  //       NULL, v->children,
+  //       (count_set_bits(v->bitmap, NUM_CHILDREN - 1) - 1) * sizeof(uint64_t));
+  //   clear_bit(v->bitmap, index);
+  } else if (is_bit_set(v->bitmap, index)) {
+    // Update the existing child
+    int compact_index = count_set_bits(v->bitmap, index) - 1;
+    v->children[compact_index] = value;
+  }
+}
+
+// Fully expand and hash node
+uint64_t pvector_hash(PVector *v) {
+  uint64_t children[NUM_CHILDREN];
+  for (size_t i = 0; i < NUM_CHILDREN; ++i)
+    children[i] = get_child(v, i);
+  return fasthash64(children, NUM_CHILDREN * sizeof(uint64_t), 0);
+}
+
 PVector *pvector_clone(PVector *v) {
   PVector *u = memory_calloc(NULL, 1, sizeof(PVector));
   u->hash = v->hash;
+  set_bit(u->bitmap, 0);
+  u->children = memory_calloc(NULL, 1, sizeof(uint64_t));
   for (size_t i = 0; i < NUM_CHILDREN; ++i)
-    u->children[i] = v->children[i];
+    set_child(u, i, get_child(v, i));
+  printf("Set bits: %.16lx\n", count_set_bits(u->bitmap, NUM_CHILDREN-1));
   return u;
 }
 
@@ -28,9 +107,9 @@ uint8_t pvector_get(PVector *t, uint64_t idx) {
   uint64_t idxn = idx >> BOTTOM_BITS;
   for (int i = MAX_DEPTH - 1; i >= 1; --i) {
     key = (idxn >> (i - 1) * BITS_PER_LEVEL) & CHILD_MASK;
-    if (v->children[key] == 0UL)
+    if (get_child(v, key) == 0UL)
       return 0; // Assume memory is 0-initialized
-    v = ht_get(ht, v->children[key]);
+    v = ht_get(ht, get_child(v, key));
   }
   return UNTAG((((PVectorLeaf *)v)->bytes))[idx & BOTTOM_MASK];
 }
@@ -41,9 +120,9 @@ PVectorLeaf *pvector_get_leaf(PVector *v, uint64_t idx) {
   uint64_t idxn = idx >> BOTTOM_BITS;
   for (int i = MAX_DEPTH - 1; i >= 1; --i) {
     key = (idxn >> (i - 1) * BITS_PER_LEVEL) & CHILD_MASK;
-    if (v->children[key] == 0UL)
+    if (get_child(v, key) == 0UL)
       return 0; // Assume memory is 0-initialized
-    v = ht_get(ht, v->children[key]);
+    v = ht_get(ht, get_child(v, key));
   }
   return (PVectorLeaf *)v;
 }
@@ -86,16 +165,16 @@ PVector *pvector_update_n_helper(PVector *v, uint64_t depth, uint64_t idx,
 
   for (uint64_t i = 0; k < mk + 1; k += 1) {
     assert(k < NUM_CHILDREN);
-    PVector *u = ht_get(ht, v->children[k]);
+    PVector *u = ht_get(ht, get_child(v, k));
     u = pvector_update_n_helper(u, depth - 1, idx + i, buf + i,
                                 MIN(inc, n - i));
 
-    if (v->children[k] != u->hash) {
+    if (get_child(v, k) != u->hash) {
       if (!cloned) {
         v = pvector_clone(v);
         cloned = 1;
       }
-      v->children[k] = u->hash;
+      set_child(v, k, u->hash);
     }
 
     i += inc;
@@ -103,12 +182,12 @@ PVector *pvector_update_n_helper(PVector *v, uint64_t depth, uint64_t idx,
   }
 
   if (cloned) {
-    v->hash = fasthash64(v->children, NUM_CHILDREN * sizeof(uint64_t), 0);
+    v->hash = pvector_hash(v);
     if (ht_get(ht, v->hash) == NULL) {
       ht_insert(ht, v->hash, v);
 
       for (uint64_t m = 0; m < NUM_CHILDREN; ++m)
-        ((PVector *)ht_get(ht, v->children[m]))->refcount++;
+        ((PVector *)ht_get(ht, get_child(v, m)))->refcount++;
     }
   }
   return v;
@@ -143,8 +222,8 @@ void pvector_gc(PVector *v, uint64_t level) {
   v->refcount--;
   if (v->refcount == 0 && level > 0) {
     for (size_t i = 0; i < NUM_CHILDREN; ++i)
-      if (v->children[i])
-        pvector_gc(ht_get(ht, v->children[i]), level - 1);
+      if (get_child(v, i))
+        pvector_gc(ht_get(ht, get_child(v, i)), level - 1);
   }
   if (v->refcount == 0) {
     ht_remove(ht, v->hash);

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,6 +1,6 @@
-#include <assert.h>
 #include <string.h>
 
+#include "cassert.h"
 #include "memory.h"
 #include "queue.h"
 


### PR DESCRIPTION
Reduces memory usage by up to 130x for larger nodes, pushes performance into competition for smaller sizes tries.